### PR TITLE
huddle: Fix misalignment in the titlebar

### DIFF
--- a/pages/huddle.tsx
+++ b/pages/huddle.tsx
@@ -20,9 +20,7 @@ const Home: NextPage = () => {
       </Head>
 
       <Navbar></Navbar>
-
-      <br></br>
-      <br></br>
+      <br />
       <Script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></Script>
       <iframe
         className="airtable-embed airtable-dynamic-height"


### PR DESCRIPTION
The huddle page in GDSC website was misaligned due to the presence of multiple break tags.

This commit solves this issue by using a single break tag which solves the misalignment.

Please add the "hacktoberfest-accepted" tag when merging my pull request.

![image](https://user-images.githubusercontent.com/82862779/195974350-c6272b96-c5a0-47c4-b1a2-24a480f3c536.png)


Fixes #11